### PR TITLE
Add download plugin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -109,7 +109,7 @@ endif
 glib_dep = dependency('glib-2.0', version: '>= 2.71.3')
 gio_dep = dependency('gio-2.0', version: '>= 2.71.3')
 peas_dep = dependency('libpeas-1.0')
-soup_dep = dependency('libsoup-3.0')
+soup_dep = dependency('libsoup-3.0', required: get_option('download-soup'))
 ws2_32_dep = cc.find_library('ws2_32', required : with_platform_windows)
 gsettings_desktop_schema = dependency('gsettings-desktop-schemas', required: get_option('config-gnome'))
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -60,3 +60,10 @@ option(
   value: true,
   description: 'Whether to build plugin for PAC Runner Duktape'
 )
+
+option(
+  'download-soup',
+  type: 'boolean',
+  value: true,
+  description: 'Whether to build plugin for downloading with SOUP'
+)

--- a/src/backend/meson.build
+++ b/src/backend/meson.build
@@ -7,12 +7,13 @@ px_backend_sources = [
   'px-plugin-config.h',
   'px-plugin-pacrunner.c',
   'px-plugin-pacrunner.h',
+  'px-plugin-download.c',
+  'px-plugin-download.h',
 ]
 
 px_backend_deps = [
   gio_dep,
   glib_dep,
-  soup_dep,
   peas_dep,
 ]
 

--- a/src/backend/plugins/download-soup/download-soup.c
+++ b/src/backend/plugins/download-soup/download-soup.c
@@ -1,0 +1,82 @@
+/* download-soup.c
+ *
+ * Copyright 2022-2023 Jan-Michael Brummer
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <libpeas/peas.h>
+#include <libsoup/soup.h>
+
+#include "download-soup.h"
+
+#include "px-plugin-download.h"
+#include "px-manager.h"
+
+static void px_download_iface_init (PxDownloadInterface *iface);
+G_MODULE_EXPORT void peas_register_types (PeasObjectModule *module);
+
+G_DEFINE_FINAL_TYPE_WITH_CODE (PxDownloadSoup,
+                               px_download_soup,
+                               G_TYPE_OBJECT,
+                               G_IMPLEMENT_INTERFACE (PX_TYPE_DOWNLOAD, px_download_iface_init))
+
+static void
+px_download_soup_init (PxDownloadSoup *self)
+{
+  self->session = soup_session_new ();
+}
+
+static void
+px_download_soup_class_init (PxDownloadSoupClass *klass)
+{
+}
+
+static GBytes *
+px_download_soup_download (PxDownload *download, const char *uri)
+{
+  PxDownloadSoup *self = PX_DOWNLOAD_SOUP (download);
+  g_autoptr (SoupMessage) msg = soup_message_new (SOUP_METHOD_GET, uri);
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = NULL;
+
+  bytes = soup_session_send_and_read (
+    self->session,
+    msg,
+    NULL,     /* Pass a GCancellable here if you want to cancel a download */
+    &error);
+  if (!bytes || soup_message_get_status (msg) != SOUP_STATUS_OK) {
+    g_debug ("Failed to download: %s\n", error ? error->message : "");
+    return NULL;
+  }
+
+  return g_steal_pointer (&bytes);
+}
+
+static void
+px_download_iface_init (PxDownloadInterface *iface)
+{
+  iface->download = px_download_soup_download;
+}
+
+G_MODULE_EXPORT void
+peas_register_types (PeasObjectModule *module)
+{
+  peas_object_module_register_extension_type (module,
+                                              PX_TYPE_DOWNLOAD,
+                                              PX_DOWNLOAD_TYPE_SOUP);
+}

--- a/src/backend/plugins/download-soup/download-soup.h
+++ b/src/backend/plugins/download-soup/download-soup.h
@@ -1,0 +1,41 @@
+/* download-soup.h
+ *
+ * Copyright 2022-2023 Jan-Michael Brummer
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <libpeas/peas.h>
+
+G_BEGIN_DECLS
+
+#define PX_DOWNLOAD_TYPE_SOUP         (px_download_soup_get_type ())
+
+G_DECLARE_FINAL_TYPE (PxDownloadSoup, px_download_soup, PX, DOWNLOAD_SOUP, GObject)
+
+struct _PxDownloadSoup {
+  GObject parent_instance;
+
+  SoupSession *session;
+};
+
+G_END_DECLS
+
+

--- a/src/backend/plugins/download-soup/download-soup.plugin
+++ b/src/backend/plugins/download-soup/download-soup.plugin
@@ -1,0 +1,6 @@
+[Plugin]
+Authors=Jan-Michael Brummer <jan.brummer@tabos.org>
+Copyright=Copyright © 2023 Jan-Michael Brummer
+Description=Donwload data using SOUP
+Module=download-soup
+Name=SOUP

--- a/src/backend/plugins/download-soup/meson.build
+++ b/src/backend/plugins/download-soup/meson.build
@@ -1,0 +1,33 @@
+plugin_name = 'download-soup'
+
+if get_option(plugin_name)
+
+plugin_src = [
+  '@0@.c'.format(plugin_name),
+]
+
+plugin_data = [
+  '@0@.plugin'.format(plugin_name),
+]
+
+plugin_lib = shared_module(
+  plugin_name,
+  sources: plugin_src,
+  include_directories: px_backend_inc,
+  dependencies: [px_backend_dep, soup_dep],
+  install_dir: join_paths(px_plugins_dir, plugin_name),
+  install: true,
+  name_suffix: module_suffix,
+)
+
+# Starting with Meson 0.64 this can be replaced with fs.copyfile
+custom_target(
+  '@0@-data'.format(plugin_name),
+  input: plugin_data,
+  output: plugin_data,
+  command: ['cp', '@INPUT@', '@OUTDIR@'],
+  install_dir: join_paths(px_plugins_dir, plugin_name),
+  install: true,
+)
+
+endif

--- a/src/backend/plugins/meson.build
+++ b/src/backend/plugins/meson.build
@@ -4,6 +4,8 @@ subdir('config-osx')
 subdir('config-sysconfig')
 subdir('config-windows')
 
+subdir('download-soup')
+
 subdir('pacrunner-duktape')
 
 summary({
@@ -12,5 +14,6 @@ summary({
   'Configuration Windows    ' : get_option('config-windows'),
   'Configuration sysconfig  ' : get_option('config-sysconfig'),
   'Configuration OS X       ' : get_option('config-osx'),
+  'Download Soup            ' : get_option('download-soup'),
   'PAC Runner Duktape       ' : get_option('pacrunner-duktape'),
 }, section: 'Plugins')

--- a/src/backend/px-plugin-download.c
+++ b/src/backend/px-plugin-download.c
@@ -1,0 +1,30 @@
+/* px-plugin-download.c
+ *
+ * Copyright 2022-2023 Jan-Michael Brummer
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+
+#include "px-plugin-download.h"
+
+G_DEFINE_INTERFACE (PxDownload, px_download, G_TYPE_OBJECT)
+
+static void
+px_download_default_init (PxDownloadInterface *iface)
+{
+}

--- a/src/backend/px-plugin-download.h
+++ b/src/backend/px-plugin-download.h
@@ -1,0 +1,39 @@
+/* px-plugin-download.h
+ *
+ * Copyright 2023 Jan-Michael Brummer
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define PX_TYPE_DOWNLOAD (px_download_get_type ())
+
+G_DECLARE_INTERFACE (PxDownload, px_download, PX, DOWNLOAD, GObject)
+
+struct _PxDownloadInterface
+{
+  GTypeInterface parent_iface;
+
+  GBytes *(*download)(PxDownload *download, const char *uri);
+};
+
+G_END_DECLS


### PR DESCRIPTION
Move PAC downloading into an own plugin so that
CURL does not depend on soup.

Relates: https://github.com/janbrummer/libproxy2/issues/2