### PR TITLE
Keep the client library abi compatible to version 0.4.x 

### DIFF
--- a/src/libproxy/libproxy.map
+++ b/src/libproxy/libproxy.map
@@ -1,0 +1,8 @@
+LIBPROXY_0.4.16 {
+  global:
+    px_proxy_factory_new;
+    px_proxy_factory_get_proxies;
+    px_proxy_factory_free_proxies;
+    px_proxy_factory_free;
+};
+

--- a/src/libproxy/meson.build
+++ b/src/libproxy/meson.build
@@ -24,10 +24,11 @@ libproxy_deps = [
 ]
 
 libproxy_lib = shared_library(
-  'proxy-@0@'.format(api_version),
+  'proxy',
   libproxy_sources,
   include_directories: px_backend_inc,
   dependencies: libproxy_deps,
+  soversion: '1',
   install: true,
 )
 

--- a/src/libproxy/meson.build
+++ b/src/libproxy/meson.build
@@ -23,11 +23,20 @@ libproxy_deps = [
   px_backend_dep,
 ]
 
+mapfile = 'libproxy.map'
+vscript = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+vflag = []
+if cc.has_multi_link_arguments(vscript)
+  vflag += vscript
+endif
+
 libproxy_lib = shared_library(
   'proxy',
   libproxy_sources,
   include_directories: px_backend_inc,
   dependencies: libproxy_deps,
+  link_args : vflag,
+  link_depends : mapfile,
   soversion: '1',
   install: true,
 )


### PR DESCRIPTION
Keep the name libproxy.so.1 for the client library and also declare that the ABI used by it is the same as introduced with libproxy 0.4.16

New public API must be added to the map with a new version identifier

Fixes https://github.com/janbrummer/libproxy2/issues/23