### PR TITLE
Take care of dbus problems

### DIFF
--- a/src/libproxy/proxy-dbus.c
+++ b/src/libproxy/proxy-dbus.c
@@ -73,6 +73,9 @@ px_proxy_factory_get_proxies (struct px_proxy_factory *self,
   gsize len;
   gsize idx;
 
+  if (!self->proxy)
+    return NULL;
+
   result = g_dbus_proxy_call_sync (self->proxy,
                                    "query",
                                    g_variant_new ("(s)", url),


### PR DESCRIPTION
In case proxy dbus service is not working, just return NULL for proxy query.