### PR TITLE
Simplify get_config API

### DIFF
--- a/src/backend/plugins/config-env/config-env.c
+++ b/src/backend/plugins/config-env/config-env.c
@@ -93,11 +93,10 @@ px_config_env_is_available (PxConfig *self)
   return TRUE;
 }
 
-static gboolean
-px_config_env_get_config (PxConfig      *config,
-                          GUri          *uri,
-                          GStrvBuilder  *builder,
-                          GError       **error)
+static void
+px_config_env_get_config (PxConfig     *config,
+                          GUri         *uri,
+                          GStrvBuilder *builder)
 {
   PxConfigEnv *self = PX_CONFIG_ENV (config);
   const char *proxy = NULL;
@@ -108,7 +107,7 @@ px_config_env_get_config (PxConfig      *config,
    * - case insensitive check?
    */
   if (self->no_proxy && (g_strv_contains ((const char * const *)self->no_proxy, g_uri_get_host (uri)) || g_strv_contains ((const char * const *)self->no_proxy, "*"))) {
-    return TRUE;
+    return;
   }
 
   if (g_strcmp0 (scheme, "ftp") == 0)
@@ -123,8 +122,6 @@ px_config_env_get_config (PxConfig      *config,
   /* TODO: Where should we add proxy url validation ? */
   if (proxy)
     g_strv_builder_add (builder, proxy);
-
-  return TRUE;
 }
 
 static void

--- a/src/backend/plugins/config-gnome/config-gnome.c
+++ b/src/backend/plugins/config-gnome/config-gnome.c
@@ -117,11 +117,10 @@ store_response (GStrvBuilder *builder,
   }
 }
 
-static gboolean
-px_config_gnome_get_config (PxConfig      *config,
-                            GUri          *uri,
-                            GStrvBuilder  *builder,
-                            GError       **error)
+static void
+px_config_gnome_get_config (PxConfig     *config,
+                            GUri         *uri,
+                            GStrvBuilder *builder)
 {
   PxConfigGnome *self = PX_CONFIG_GNOME (config);
   g_autofree char *proxy = NULL;
@@ -181,8 +180,6 @@ px_config_gnome_get_config (PxConfig      *config,
                       password);
     }
   }
-
-  return TRUE;
 }
 
 static void

--- a/src/backend/plugins/config-kde/config-kde.c
+++ b/src/backend/plugins/config-kde/config-kde.c
@@ -152,21 +152,20 @@ px_config_kde_is_available (PxConfig *config)
   return self->available && g_getenv ("KDE_FULL_SESSION") != NULL;
 }
 
-static gboolean
-px_config_kde_get_config (PxConfig      *config,
-                          GUri          *uri,
-                          GStrvBuilder  *builder,
-                          GError       **error)
+static void
+px_config_kde_get_config (PxConfig     *config,
+                          GUri         *uri,
+                          GStrvBuilder *builder)
 {
   PxConfigKde *self = PX_CONFIG_KDE (config);
   const char *scheme = g_uri_get_scheme (uri);
   g_autofree char *proxy = NULL;
 
   if (!self->proxy_type)
-    return TRUE;
+    return;
 
   if (self->no_proxy && strstr (self->no_proxy, g_uri_get_host (uri)))
-    return TRUE;
+    return;
 
   switch (self->proxy_type) {
     case KDE_PROXY_TYPE_MANUAL:
@@ -194,8 +193,6 @@ px_config_kde_get_config (PxConfig      *config,
 
   if (proxy)
     g_strv_builder_add (builder, proxy);
-
-  return TRUE;
 }
 
 static void

--- a/src/backend/plugins/config-osx/config-osx.c
+++ b/src/backend/plugins/config-osx/config-osx.c
@@ -119,24 +119,23 @@ getbool (CFDictionaryRef  settings,
   return i != 0;
 }
 
-static gboolean
-px_config_osx_get_config (PxConfig      *self,
-                          GUri          *uri,
-                          GStrvBuilder  *builder,
-                          GError       **error)
+static void
+px_config_osx_get_config (PxConfig     *self,
+                          GUri         *uri,
+                          GStrvBuilder *builder)
 {
   const char *proxy = NULL;
   CFDictionaryRef proxies = SCDynamicStoreCopyProxies (NULL);
 
   if (!proxies) {
     g_warning ("Unable to fetch proxy configuration");
-    return FALSE;
+    return;
   }
 
   if (getbool (proxies, "ProxyAutoDiscoveryEnable")) {
     CFRelease (proxies);
     g_strv_builder_add (builder, "wpad://");
-    return TRUE;
+    return;
   }
 
   if (getbool (proxies, "ProxyAutoConfigEnable")) {
@@ -148,15 +147,13 @@ px_config_osx_get_config (PxConfig      *self,
       g_autofree char *ret = g_strdup_printf ("pac+%s", g_uri_to_string (tmp_uri));
       CFRelease (proxies);
       g_strv_builder_add (builder, ret);
-      return TRUE;
+      return;
     }
   }
 
   g_print ("%s: Whatever", __FUNCTION__);
   if (proxy)
     g_strv_builder_add (builder, proxy);
-
-  return TRUE;
 }
 
 static void

--- a/src/backend/plugins/config-sysconfig/config-sysconfig.c
+++ b/src/backend/plugins/config-sysconfig/config-sysconfig.c
@@ -122,21 +122,20 @@ px_config_sysconfig_is_available (PxConfig *config)
   return self->available;
 }
 
-static gboolean
-px_config_sysconfig_get_config (PxConfig      *config,
-                                GUri          *uri,
-                                GStrvBuilder  *builder,
-                                GError       **error)
+static void
+px_config_sysconfig_get_config (PxConfig     *config,
+                                GUri         *uri,
+                                GStrvBuilder *builder)
 {
   PxConfigSysConfig *self = PX_CONFIG_SYSCONFIG (config);
   const char *scheme = g_uri_get_scheme (uri);
   g_autofree char *proxy = NULL;
 
   if (!self->proxy_enabled)
-    return TRUE;
+    return;
 
   if (self->no_proxy && strstr (self->no_proxy, g_uri_get_host (uri)))
-    return TRUE;
+    return;
 
   if (g_strcmp0 (scheme, "ftp") == 0) {
     proxy = g_strdup (self->ftp_proxy);
@@ -148,8 +147,6 @@ px_config_sysconfig_get_config (PxConfig      *config,
 
   if (proxy)
     g_strv_builder_add (builder, proxy);
-
-  return TRUE;
 }
 
 static void

--- a/src/backend/plugins/config-windows/config-windows.c
+++ b/src/backend/plugins/config-windows/config-windows.c
@@ -123,11 +123,10 @@ is_enabled (char type)
   return result;
 }
 
-static gboolean
-px_config_windows_get_config (PxConfig      *self,
-                              GUri          *uri,
-                              GStrvBuilder  *builder,
-                              GError       **error)
+static void
+px_config_windows_get_config (PxConfig     *self,
+                              GUri         *uri,
+                              GStrvBuilder *builder)
 {
   char *tmp = NULL;
   guint32 enabled = 0;
@@ -139,7 +138,7 @@ px_config_windows_get_config (PxConfig      *self,
   /* WPAD */
   if (is_enabled (W32REG_OFFSET_WPAD)) {
     g_strv_builder_add (builder, "wpad://");
-    return TRUE;
+    return;
   }
 
   /* PAC */
@@ -149,7 +148,7 @@ px_config_windows_get_config (PxConfig      *self,
 
     if (ac_uri) {
       g_strv_builder_add (builder, pac_uri);
-      return TRUE;
+      return;
     }
   }
 
@@ -158,10 +157,8 @@ px_config_windows_get_config (PxConfig      *self,
     g_autofree char *http_proxy = g_strconcat ("http://", tmp, NULL);
     /* TODO */
     g_strv_builder_add (builder, http_proxy);
-    return TRUE;
+    return;
   }
-
-  return TRUE;
 }
 
 static void

--- a/src/backend/px-manager.c
+++ b/src/backend/px-manager.c
@@ -295,7 +295,6 @@ px_manager_pac_download (PxManager  *self,
 struct ConfigData {
   GStrvBuilder *builder;
   GUri *uri;
-  GError **error;
 };
 
 /**
@@ -313,7 +312,7 @@ get_config (PeasExtensionSet *set,
   struct ConfigData *config_data = data;
 
   g_debug ("%s: Asking plugin '%s' for configuration", __FUNCTION__, peas_plugin_info_get_module_name (info));
-  ifc->get_config (PX_CONFIG (extension), config_data->uri, config_data->builder, config_data->error);
+  ifc->get_config (PX_CONFIG (extension), config_data->uri, config_data->builder);
 }
 
 /**
@@ -335,7 +334,6 @@ px_manager_get_configuration (PxManager  *self,
   struct ConfigData config_data = {
     .uri = uri,
     .builder = builder,
-    .error = error,
   };
 
   peas_extension_set_foreach (self->config_set, get_config, &config_data);

--- a/src/backend/px-plugin-config.h
+++ b/src/backend/px-plugin-config.h
@@ -34,7 +34,7 @@ struct _PxConfigInterface
   GTypeInterface parent_iface;
 
   gboolean (*is_available) (PxConfig *self);
-  gboolean (*get_config) (PxConfig *self, GUri *uri, GStrvBuilder *builder, GError **error);
+  void (*get_config) (PxConfig *self, GUri *uri, GStrvBuilder *builder);
 };
 
 G_END_DECLS


### PR DESCRIPTION
Remove return value as it was unused, as well as GError. In case an error occures we can dump it into debug. There is no user benefit.