### PR TITLE
Add config-option property

### DIFF
--- a/src/backend/plugins/config-env/config-env.c
+++ b/src/backend/plugins/config-env/config-env.c
@@ -43,6 +43,11 @@ G_DEFINE_FINAL_TYPE_WITH_CODE (PxConfigEnv,
                                G_TYPE_OBJECT,
                                G_IMPLEMENT_INTERFACE (PX_TYPE_CONFIG, px_config_iface_init))
 
+enum {
+  PROP_0,
+  PROP_CONFIG_OPTION
+};
+
 static void
 px_config_env_init (PxConfigEnv *self)
 {
@@ -80,11 +85,47 @@ px_config_env_dispose (GObject *object)
 }
 
 static void
+px_config_env_set_property (GObject      *object,
+                            guint         prop_id,
+                            const GValue *value,
+                            GParamSpec   *pspec)
+{
+  switch (prop_id) {
+    case PROP_CONFIG_OPTION:
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+px_config_env_get_property (GObject    *object,
+                            guint       prop_id,
+                            GValue     *value,
+                            GParamSpec *pspec)
+{
+  switch (prop_id) {
+    case PROP_CONFIG_OPTION:
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
 px_config_env_class_init (PxConfigEnvClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
   object_class->dispose = px_config_env_dispose;
+  object_class->set_property = px_config_env_set_property;
+  object_class->get_property = px_config_env_get_property;
+
+  g_object_class_override_property (object_class, PROP_CONFIG_OPTION, "config-option");
 }
 
 static gboolean

--- a/src/backend/plugins/config-gnome/config-gnome.c
+++ b/src/backend/plugins/config-gnome/config-gnome.c
@@ -49,6 +49,11 @@ G_DEFINE_FINAL_TYPE_WITH_CODE (PxConfigGnome,
                                G_TYPE_OBJECT,
                                G_IMPLEMENT_INTERFACE (PX_TYPE_CONFIG, px_config_iface_init))
 
+enum {
+  PROP_0,
+  PROP_CONFIG_OPTION
+};
+
 static void
 px_config_gnome_init (PxConfigGnome *self)
 {
@@ -74,8 +79,46 @@ px_config_gnome_init (PxConfigGnome *self)
 }
 
 static void
+px_config_gnome_set_property (GObject      *object,
+                              guint         prop_id,
+                              const GValue *value,
+                              GParamSpec   *pspec)
+{
+  switch (prop_id) {
+    case PROP_CONFIG_OPTION:
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+px_config_gnome_get_property (GObject    *object,
+                              guint       prop_id,
+                              GValue     *value,
+                              GParamSpec *pspec)
+{
+  switch (prop_id) {
+    case PROP_CONFIG_OPTION:
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
 px_config_gnome_class_init (PxConfigGnomeClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = px_config_gnome_set_property;
+  object_class->get_property = px_config_gnome_get_property;
+
+  g_object_class_override_property (object_class, PROP_CONFIG_OPTION, "config-option");
 }
 
 static gboolean

--- a/src/backend/px-manager.h
+++ b/src/backend/px-manager.h
@@ -49,6 +49,8 @@ typedef enum {
 
 
 PxManager *px_manager_new (void);
+PxManager *px_manager_new_with_options (const char *optname1, ...);
+
 char **px_manager_get_proxies_sync (PxManager   *self,
                                     const char  *url,
                                     GError     **error);

--- a/src/backend/px-plugin-config.c
+++ b/src/backend/px-plugin-config.c
@@ -27,4 +27,12 @@ G_DEFINE_INTERFACE (PxConfig, px_config, G_TYPE_OBJECT)
 static void
 px_config_default_init (PxConfigInterface *iface)
 {
+  g_object_interface_install_property (iface,
+                                       g_param_spec_string ("config-option",
+                                                            NULL,
+                                                            NULL,
+                                                            NULL,
+                                                            G_PARAM_READWRITE |
+                                                            G_PARAM_CONSTRUCT_ONLY |
+                                                            G_PARAM_STATIC_STRINGS));
 }

--- a/tests/config-env-test.c
+++ b/tests/config-env-test.c
@@ -75,7 +75,7 @@ test_config_env (void)
         g_setenv ("no_proxy", test.no_proxy, TRUE);
     }
 
-    manager = px_test_manager_new ("config-env");
+    manager = px_test_manager_new ("config-env", NULL);
     g_clear_error (&error);
 
     uri = g_uri_parse (test.url, G_URI_FLAGS_PARSE_RELAXED, &error);

--- a/tests/config-gnome-test.c
+++ b/tests/config-gnome-test.c
@@ -96,7 +96,7 @@ test_config_gnome_manual (Fixture    *self,
     g_settings_set_string (self->socks_proxy_settings, "host", test.proxy);
     g_settings_set_int (self->socks_proxy_settings, "port", test.proxy_port);
 
-    manager = px_test_manager_new ("config-gnome");
+    manager = px_test_manager_new ("config-gnome", NULL);
     g_clear_error (&error);
 
     uri = g_uri_parse (test.url, G_URI_FLAGS_PARSE_RELAXED, &error);
@@ -128,7 +128,7 @@ test_config_gnome_manual_auth (Fixture    *self,
   g_settings_set_string (self->http_proxy_settings, "authentication-user", "test");
   g_settings_set_string (self->http_proxy_settings, "authentication-password", "pwd");
 
-  manager = px_test_manager_new ("config-gnome");
+  manager = px_test_manager_new ("config-gnome", NULL);
   g_clear_error (&error);
 
   uri = g_uri_parse ("http://www.example.com", G_URI_FLAGS_PARSE_RELAXED, &error);
@@ -146,7 +146,7 @@ test_config_gnome_auto (Fixture    *self,
   g_auto (GStrv) config = NULL;
   g_autoptr (GUri) uri = NULL;
 
-  manager = px_test_manager_new ("config-gnome");
+  manager = px_test_manager_new ("config-gnome", NULL);
   g_settings_set_enum (self->proxy_settings, "mode", GNOME_PROXY_MODE_AUTO);
   g_settings_set_string (self->proxy_settings, "autoconfig-url", "");
 
@@ -171,7 +171,7 @@ test_config_gnome_fail (Fixture    *self,
   /* Disable GNOME support */
   g_setenv ("XDG_CURRENT_DESKTOP", "unknown", TRUE);
 
-  manager = px_test_manager_new ("config-gnome");
+  manager = px_test_manager_new ("config-gnome", NULL);
   g_settings_set_enum (self->proxy_settings, "mode", GNOME_PROXY_MODE_AUTO);
   g_settings_set_string (self->proxy_settings, "autoconfig-url", "");
 

--- a/tests/config-kde-test.c
+++ b/tests/config-kde-test.c
@@ -64,12 +64,7 @@ test_config_kde_disabled (void)
     ConfigKdeTest test = config_kde_manual_test_set[idx];
     g_autofree char *path = g_test_build_filename (G_TEST_DIST, "data", "sample-kde-proxy-disabled", NULL);
 
-    if (!g_setenv ("PX_CONFIG_KDE", path, TRUE)) {
-      g_warning ("Failed to set kde environment");
-      continue;
-    }
-
-    manager = px_test_manager_new ("config-kde");
+    manager = px_test_manager_new ("config-kde", path);
     g_clear_error (&error);
 
     uri = g_uri_parse (test.url, G_URI_FLAGS_PARSE_RELAXED, &error);
@@ -98,12 +93,7 @@ test_config_kde_manual (void)
     ConfigKdeTest test = config_kde_manual_test_set[idx];
     g_autofree char *path = g_test_build_filename (G_TEST_DIST, "data", "sample-kde-proxy-manual", NULL);
 
-    if (!g_setenv ("PX_CONFIG_KDE", path, TRUE)) {
-      g_warning ("Failed to set kde environment");
-      continue;
-    }
-
-    manager = px_test_manager_new ("config-kde");
+    manager = px_test_manager_new ("config-kde", path);
     g_clear_error (&error);
 
     uri = g_uri_parse (test.url, G_URI_FLAGS_PARSE_RELAXED, &error);
@@ -135,12 +125,7 @@ test_config_kde_wpad (void)
     ConfigKdeTest test = config_kde_wpad_test_set[idx];
     g_autofree char *path = g_test_build_filename (G_TEST_DIST, "data", "sample-kde-proxy-wpad", NULL);
 
-    if (!g_setenv ("PX_CONFIG_KDE", path, TRUE)) {
-      g_warning ("Failed to set kde environment");
-      continue;
-    }
-
-    manager = px_test_manager_new ("config-kde");
+    manager = px_test_manager_new ("config-kde", path);
     g_clear_error (&error);
 
     uri = g_uri_parse (test.url, G_URI_FLAGS_PARSE_RELAXED, &error);
@@ -172,12 +157,7 @@ test_config_kde_pac (void)
     ConfigKdeTest test = config_kde_pac_test_set[idx];
     g_autofree char *path = g_test_build_filename (G_TEST_DIST, "data", "sample-kde-proxy-pac", NULL);
 
-    if (!g_setenv ("PX_CONFIG_KDE", path, TRUE)) {
-      g_warning ("Failed to set kde environment");
-      continue;
-    }
-
-    manager = px_test_manager_new ("config-kde");
+    manager = px_test_manager_new ("config-kde", path);
     g_clear_error (&error);
 
     uri = g_uri_parse (test.url, G_URI_FLAGS_PARSE_RELAXED, &error);
@@ -205,14 +185,10 @@ test_config_kde_fail (void)
   g_auto (GStrv) config = NULL;
   g_autofree char *path = g_test_build_filename (G_TEST_DIST, "data", "sample-kde-proxy-pac", NULL);
 
-  if (!g_setenv ("PX_CONFIG_KDE", path, TRUE)) {
-    g_warning ("Failed to set kde environment");
-  }
-
   /* Disable KDE support */
   g_unsetenv ("KDE_FULL_SESSION");
 
-  manager = px_test_manager_new ("config-kde");
+  manager = px_test_manager_new ("config-kde", path);
 
   uri = g_uri_parse ("https://www.example.com", G_URI_FLAGS_PARSE_RELAXED, &error);
 

--- a/tests/config-sysconfig-test.c
+++ b/tests/config-sysconfig-test.c
@@ -49,12 +49,7 @@ test_config_sysconfig (void)
     ConfigSysConfigTest test = config_sysconfig_test_set[idx];
     g_autofree char *path = g_test_build_filename (G_TEST_DIST, "data", "sample-sysconfig-proxy", NULL);
 
-    if (!g_setenv ("PX_CONFIG_SYSCONFIG", path, TRUE)) {
-      g_warning ("Failed to set sysconfig environment");
-      continue;
-    }
-
-    manager = px_test_manager_new ("config-sysconfig");
+    manager = px_test_manager_new ("config-sysconfig", path);
     g_clear_error (&error);
 
     uri = g_uri_parse (test.url, G_URI_FLAGS_PARSE_RELAXED, &error);

--- a/tests/px-manager-helper.c
+++ b/tests/px-manager-helper.c
@@ -23,12 +23,12 @@
 #include "px-manager-helper.h"
 
 PxManager *
-px_test_manager_new (const char *config_plugin)
+px_test_manager_new (const char *config_plugin, const char *config_option)
 {
   g_autofree char *path = g_test_build_filename (G_TEST_BUILT, "../src/backend/plugins", NULL);
 
-  return g_object_new (PX_TYPE_MANAGER,
-                       "plugins-dir", path,
-                       "config-plugin", config_plugin,
-                       NULL);
+  return px_manager_new_with_options ("plugins-dir", path,
+                                      "config-plugin", config_plugin,
+                                      "config-option", config_option,
+                                      NULL);
 }

--- a/tests/px-manager-helper.h
+++ b/tests/px-manager-helper.h
@@ -21,4 +21,4 @@
 
 #pragma once
 
-PxManager *px_test_manager_new (const char *config_plugin);
+PxManager *px_test_manager_new (const char *config_plugin, const char *config_option);

--- a/tests/px-manager-test.c
+++ b/tests/px-manager-test.c
@@ -59,24 +59,20 @@ static void
 fixture_setup (Fixture       *fixture,
                gconstpointer  data)
 {
+  g_autofree char *path = NULL;
+
   fixture->loop = g_main_loop_new (NULL, FALSE);
 
-  if (data) {
-    g_autofree char *path = g_test_build_filename (G_TEST_DIST, "data", data, NULL);
-    if (!g_setenv ("PX_CONFIG_SYSCONFIG", path, TRUE)) {
-      g_warning ("Failed to set environment");
-      return;
-    }
-  }
+  if (data)
+    path = g_test_build_filename (G_TEST_DIST, "data", data, NULL);
 
-  fixture->manager = px_test_manager_new ("config-sysconfig");
+  fixture->manager = px_test_manager_new ("config-sysconfig", path);
 }
 
 static void
 fixture_teardown (Fixture       *fixture,
                   gconstpointer  data)
 {
-  g_unsetenv ("PX_CONFIG_SYSCONFIG");
   g_clear_object (&fixture->manager);
 }
 


### PR DESCRIPTION
In order to reduce the number of environment manipulation for testing purpose, introduce a new config-option property to set config files for tests.